### PR TITLE
JBake Permalinks

### DIFF
--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -89,3 +89,5 @@ db.path=cache
 uri.noExtension=false
 # Set to a prefix path (starting with a slash) for which to generate extension-less URI's (i.e. a folder with index.html in)
 uri.noExtension.prefix=
+# set the default permalink to source filepath.
+permalink=/:filepath

--- a/src/test/java/org/jbake/app/CrawlerTest.java
+++ b/src/test/java/org/jbake/app/CrawlerTest.java
@@ -1,19 +1,13 @@
 package org.jbake.app;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
-import java.util.Map;
-
-import com.orientechnologies.orient.core.record.impl.ODocument;
-import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-
-import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.jbake.app.ConfigUtil.Keys;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.configuration.CompositeConfiguration;
@@ -22,18 +16,19 @@ import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FilenameUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.jbake.app.ConfigUtil.Keys;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 
 public class CrawlerTest {
     private CompositeConfiguration config;
     private ContentStore db;
     private File sourceFolder;
-	
+	  
 	@Before
     public void setup() throws Exception, IOException, URISyntaxException {
         URL sourceUrl = this.getClass().getResource("/");
@@ -42,7 +37,7 @@ public class CrawlerTest {
         if (!sourceFolder.exists()) {
             throw new Exception("Cannot find sample data structure!");
         }
-
+        
         config = ConfigUtil.load(new File(this.getClass().getResource("/").getFile()));
         Assert.assertEquals(".html", config.getString(Keys.OUTPUT_EXTENSION));
         db = DBUtil.createDataStore("memory", "documents"+System.currentTimeMillis());
@@ -123,5 +118,137 @@ public class CrawlerTest {
 	    public static RegexMatcher matches(String regex){
 	        return new RegexMatcher(regex);
 	    }
+	}
+	
+	
+	private Map<String,Object> getPermalinkPost(String permalinkPattern){
+		config.setProperty("permalink", permalinkPattern);
+		Crawler crawler = new Crawler(db, sourceFolder, config);
+        crawler.crawl(new File(sourceFolder.getPath() + File.separator + config.getString(Keys.CONTENT_FOLDER)));
+        
+        List<ODocument> results = db.getPublishedPostsByTag("PermalinkTest");
+        
+        assertThat(results.size()).isEqualTo(1);
+        
+		DocumentList list = DocumentList.wrap(results.iterator());
+		Map<String,Object> content = list.getFirst();
+		return content;
+	}
+	
+	@Test
+	public void testPermalinkFilePath(){
+
+		Map<String,Object> content = getPermalinkPost("/:filepath");
+        
+		assertThat(content.get("uri")).isEqualTo("blog/2013/second-post.html");
+		assertThat(content.get("uri")).isEqualTo(content.get("permalink"));
+		assertThat(content)
+		.containsKey(Crawler.Attributes.ROOTPATH)
+		.containsValue("../../");
+		
+	}
+	
+	@Test
+	public void testPermalinkFilePathWithStatic(){
+		
+		Map<String,Object> content = getPermalinkPost("/:data:/:filepath");
+        
+		assertThat(content.get("uri")).isEqualTo("data/blog/2013/second-post.html");
+		assertThat(content.get("uri")).isEqualTo(content.get("permalink"));
+		assertThat(content)
+		.containsKey(Crawler.Attributes.ROOTPATH)
+		.containsValue("../../../");
+	}
+	
+	@Test
+	public void testPermalinkFilename(){
+		
+		Map<String,Object> content = getPermalinkPost("/:blog:/:filename");
+        
+		assertThat(content.get("uri")).isEqualTo("blog/second-post.html");
+		assertThat(content.get("uri")).isEqualTo(content.get("permalink"));
+		assertThat(content)
+		.containsKey(Crawler.Attributes.ROOTPATH)
+		.containsValue("../");
+	}
+	
+	@Test
+	public void testPermalinkWithDate(){
+		
+		Map<String,Object> content = getPermalinkPost("/:blog:/:YEAR/:MONTH/:DAY/:filename");
+        
+		assertThat(content.get("uri")).isEqualTo("blog/2013/02/28/second-post.html");
+		assertThat(content.get("uri")).isEqualTo(content.get("permalink"));
+		assertThat(content)
+		.containsKey(Crawler.Attributes.ROOTPATH)
+		.containsValue("../../../../");
+	}
+	
+	@Test
+	public void testPermalinkWithTagAndTitle(){
+		
+		Map<String,Object> content = getPermalinkPost("/:data:/:tags/:title");
+        
+		assertThat(content.get("uri")).isEqualTo("data/blog/PermalinkTest/Second-Post.html");
+		assertThat(content.get("uri")).isEqualTo(content.get("permalink"));
+		assertThat(content)
+		.containsKey(Crawler.Attributes.ROOTPATH)
+		.containsValue("../../../");
+	}
+
+	
+	@Test
+	public void testPermalinkWithTagAndTitleWithNoExtension(){
+		config.setProperty("uri.noExtension", true);
+		Map<String,Object> content = getPermalinkPost("/:data:/:tags/:title");
+        
+		assertThat(content.get("uri")).isEqualTo("data/blog/PermalinkTest/Second-Post/index.html");
+		assertThat(content.get("permalink")).isEqualTo("data/blog/PermalinkTest/Second-Post/");
+		assertThat(content)
+		.containsKey(Crawler.Attributes.ROOTPATH)
+		.containsValue("../../../../");
+	}
+	
+	@Test
+	public void testPermalinkWithTypePermalink(){
+		config.setProperty("permalink", "/:filepath");
+		config.setProperty("permalink.post", "/:blog:/:filename");
+		Map<String,Object> content = getPermalinkPost("/:filepath");
+        
+		assertThat(content.get("uri")).isEqualTo("blog/second-post.html");
+		assertThat(content.get("uri")).isEqualTo(content.get("permalink"));
+		assertThat(content)
+		.containsKey(Crawler.Attributes.ROOTPATH)
+		.containsValue("../");
+	}
+	
+	@Test
+	public void testPermalinkWithMultipleTypePermalink(){
+		config.setProperty("permalink", "/:filepath");
+		config.setProperty("permalink.post", "/:blog:/:filename");
+		config.setProperty("permalink.page", "/:pages:/:filename");
+		Crawler crawler = new Crawler(db, sourceFolder, config);
+        crawler.crawl(new File(sourceFolder.getPath() + File.separator + config.getString(Keys.CONTENT_FOLDER)));
+        
+        List<ODocument> results = db.getPublishedPostsByTag("PermalinkTest");
+        
+        assertThat(results.size()).isEqualTo(1);
+        
+		DocumentList list = DocumentList.wrap(results.iterator());
+		Map<String,Object> content = list.getFirst();
+        
+		//Verify that post has used permalink.post pattern.
+		assertThat(content.get("uri")).isEqualTo("blog/second-post.html");
+		assertThat(content.get("uri")).isEqualTo(content.get("permalink"));
+		
+		List<ODocument> pageResults = db.getPublishedPages();
+          
+		DocumentList pages = DocumentList.wrap(pageResults.iterator());
+		//Verify that page has used permalink.page pattern.
+		Map<String,Object> page = pages.getFirst();
+        String url = "pages/"+FilenameUtils.getBaseName((String) page.get("file")) + ".html";
+		assertThat(page.get("uri")).isEqualTo(url);
+		assertThat(page.get("uri")).isEqualTo(page.get("permalink"));
+		
 	}
 }

--- a/src/test/resources/content/blog/2013/second-post.html
+++ b/src/test/resources/content/blog/2013/second-post.html
@@ -1,7 +1,7 @@
 title=Second Post
 date=2013-02-28
 type=post
-tags=blog
+tags=blog,PermalinkTest
 status=published
 og={"description": "Something"}
 ~~~~~~


### PR DESCRIPTION
https://github.com/jbake-org/jbake/pull/294

This pull request implements Permalink/URI Generation and customization in JBake.

It is driven by a property `permalink` in jbake.properties file. Sample permalink pattern can be `permalink=/:blog:/:title` which will generate urls as `blog\first-post.html`.

If `permalink` is not specified then default pattern is `/:filepath`.

Every keyword should be separated with '/:'. It allows you to use **any keywords** from content header. eg. `/:slug/:tags/:title`.

### Few Rules:
Some keywords are reserved for specific format. Below is the list of such keywords - 

1. **`/:filepath`**: This keyword will result it addition of relative source file path from `content` folder. If you want to maintain the content folder structure in output then, `permalink=/:filepath` will result in generating URI structure same as source files.
2. **`/:filename`**: This keyword will result in addition of source file name (without extension).
3. **`/:YEAR`, `/:MONTH`, `:DAY`**: These keywords will add a related date part from content published date to url.
4. **Adding Static words** - Static words can be added in url by using ':' as suffix in permalink. For example, `permalink=/:blog:/:filename` will result in generation of urls like /blog/First-post.html

### Using permalink in templates
Generated permalinks can be accessed in templates as `content.permalink`.

### Extension-less permalinks
If `ur.noExtension` is set to `true` then all permalinks will be extension-less. For example, `permalink=/:blog:/:filename` will generate `/blog/First-post/`.

### How to use different permalink patterns for each content type.
It is possible to use different permalink patterns based on content type. For example, post and page content type can use their own permalink patterns. `permalink` property will always be used as a default pattern for every content. To customize it based on content type, you can add another property `permalink.{type}` and specify pattern for it.

Sample configuration -
`permalink=/:filepath`
`permalink.post=/:blog:/:filename`
`permalink.page=/:filename`

Above configuration will result in pages with uri as filenames only, while posts will have suffix /blog/ for url. Any other content type will keep using `/:filepath` pattern.

