### PR TITLE
Prevent image source path from breaking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ ext {
     jsonSimpleVersion = '1.1.1'
     jade4jVersion = '1.2.5'
     mockitoVersion = '1.10.19'
+    jsoupVersion = '1.10.2'
 }
 
 dependencies {
@@ -68,6 +69,7 @@ dependencies {
     compile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
     compile group: 'ch.qos.logback', name: 'logback-core', version: logbackVersion
     compile group: 'de.neuland-bfi', name: 'jade4j', version: jade4jVersion
+	compile group: 'org.jsoup', name:'jsoup', version: jsoupVersion
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'org.assertj', name: 'assertj-core', version: assertjCoreVersion
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion

--- a/src/main/java/org/jbake/app/Crawler.java
+++ b/src/main/java/org/jbake/app/Crawler.java
@@ -1,7 +1,11 @@
 package org.jbake.app;
 
 
-import com.orientechnologies.orient.core.record.impl.ODocument;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.io.FilenameUtils;
 import org.jbake.app.ConfigUtil.Keys;
@@ -12,12 +16,7 @@ import org.jbake.model.DocumentTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Map;
-
-import static java.io.File.separator;
+import com.orientechnologies.orient.core.record.impl.ODocument;
 
 /**
  * Crawls a file system looking for content.
@@ -178,6 +177,10 @@ public class Crawler {
             if (config.getBoolean(Keys.URI_NO_EXTENSION)) {
             	fileContents.put(Attributes.NO_EXTENSION_URI, uri.replace("/index.html", "/"));
             }
+            
+            
+            // Prevent image source url's from breaking
+            HtmlUtil.fixImageSourceUrls(fileContents);
 
             ODocument doc = new ODocument(documentType);
             doc.fields(fileContents);

--- a/src/main/java/org/jbake/app/HtmlUtil.java
+++ b/src/main/java/org/jbake/app/HtmlUtil.java
@@ -1,0 +1,75 @@
+package org.jbake.app;
+
+import java.util.Map;
+
+import org.jbake.app.Crawler.Attributes;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * 
+ * @author Manik Magar
+ *
+ */
+public class HtmlUtil {
+
+	/**
+	 * Image paths are specified as w.r.t. assets folder. This function prefix rootpath to all img src except 
+	 * the ones that starts with http://, https:// or '/'.
+	 * 
+	 * If image path starts with "./", i.e. relative to the source file, then it first replace that with output file directory and the add rootpath.
+	 * 
+	 * @param fileContents
+	 */
+    public static void fixImageSourceUrls(Map<String, Object> fileContents){
+    	
+    	String htmlContent = fileContents.get(Attributes.BODY).toString();
+    	
+    	String rootPath = fileContents.get(Attributes.ROOTPATH).toString();
+    	
+    	String uri = fileContents.get(Attributes.URI).toString();
+    	
+    	if(fileContents.get(Attributes.NO_EXTENSION_URI) != null){
+    		uri = fileContents.get(Attributes.NO_EXTENSION_URI).toString();
+    		
+    		//remove trailing "/"
+    		if(uri.endsWith("/")) {
+    			uri = uri.substring(0, uri.length() - 1);
+    		}
+    		
+    	}
+    	
+    	if(uri.contains("/")){
+        	//strip that file name, leaving end "/"
+        		uri = uri.substring(0, uri.lastIndexOf("/") + 1);
+        }
+    	
+    	
+		
+    	Document document = Jsoup.parseBodyFragment(htmlContent);
+    	
+    	Elements allImgs = document.getElementsByTag("img");
+    	
+    	for (Element img : allImgs) {
+			String source = img.attr("src");
+			
+			if(source.startsWith("./")){
+				// image relative to current content is specified,
+				// lets add current url to it.
+				source = source.replaceFirst("./", uri);
+			}
+			
+			// Now add the root path
+			if((source.startsWith("http://") 
+					|| source.startsWith("https://") || source.startsWith("/")) == false){
+				String relativeSource = rootPath + source;
+				img.attr("src", relativeSource);
+			}
+		}
+    	
+    	fileContents.put(Attributes.BODY, document.body().toString());
+    }
+	
+}

--- a/src/test/java/org/jbake/app/HtmlUtilTest.java
+++ b/src/test/java/org/jbake/app/HtmlUtilTest.java
@@ -1,0 +1,108 @@
+package org.jbake.app;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jbake.app.Crawler.Attributes;
+import org.junit.Test;
+
+
+
+public class HtmlUtilTest {
+
+	@Test
+	public void shouldAddRootpath(){
+		Map<String, Object> fileContent = new HashMap<String, Object>();
+		fileContent.put(Attributes.ROOTPATH, "../../../");
+		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+		fileContent.put(Attributes.BODY, "<div> Test <img src='blog/2017/05/first.jpg' /></div>");
+		
+		HtmlUtil.fixImageSourceUrls(fileContent);
+		
+		assertTrue(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
+		
+	}
+	
+	@Test
+	public void shouldAddContentpath(){
+		Map<String, Object> fileContent = new HashMap<String, Object>();
+		fileContent.put(Attributes.ROOTPATH, "../../../");
+		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+		fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
+		
+		HtmlUtil.fixImageSourceUrls(fileContent);
+		
+		assertTrue(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
+		
+	}
+	
+	@Test
+	public void shouldNotAddRootPath(){
+		Map<String, Object> fileContent = new HashMap<String, Object>();
+		fileContent.put(Attributes.ROOTPATH, "../../../");
+		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+		fileContent.put(Attributes.BODY, "<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
+		
+		HtmlUtil.fixImageSourceUrls(fileContent);
+		
+		assertFalse(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
+		assertTrue(fileContent.get(Attributes.BODY).toString().contains("/blog/2017/05/first.jpg"));
+		
+	}
+	
+	@Test
+	public void shouldAddRootPathForNoExtension(){
+		Map<String, Object> fileContent = new HashMap<String, Object>();
+		fileContent.put(Attributes.ROOTPATH, "../../../");
+		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+		fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
+		fileContent.put(Attributes.BODY, "<div> Test <img src='blog/2017/05/first.jpg' /></div>");
+		
+		HtmlUtil.fixImageSourceUrls(fileContent);
+		
+		assertTrue(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
+
+	}
+	
+	@Test
+	public void shouldAddContentPathForNoExtension(){
+		Map<String, Object> fileContent = new HashMap<String, Object>();
+		fileContent.put(Attributes.ROOTPATH, "../../../");
+		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+		fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
+		fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
+		
+		HtmlUtil.fixImageSourceUrls(fileContent);
+		
+		assertTrue(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
+
+	}
+	
+	@Test
+	public void shouldNotChangeForHTTP(){
+		Map<String, Object> fileContent = new HashMap<String, Object>();
+		fileContent.put(Attributes.ROOTPATH, "../../../");
+		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+		fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
+		fileContent.put(Attributes.BODY, "<div> Test <img src='http://example.com/first.jpg' /></div>");
+		
+		HtmlUtil.fixImageSourceUrls(fileContent);
+		assertTrue(fileContent.get(Attributes.BODY).toString().contains("http://example.com/first.jpg"));
+
+	}
+	
+	@Test
+	public void shouldNotChangeForHTTPS(){
+		Map<String, Object> fileContent = new HashMap<String, Object>();
+		fileContent.put(Attributes.ROOTPATH, "../../../");
+		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
+		fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
+		fileContent.put(Attributes.BODY, "<div> Test <img src='https://example.com/first.jpg' /></div>");
+		
+		HtmlUtil.fixImageSourceUrls(fileContent);
+		assertTrue(fileContent.get(Attributes.BODY).toString().contains("https://example.com/first.jpg"));
+
+	}
+}


### PR DESCRIPTION
This change prevents image source path from breaking. It prefixes
content rootpath the image sources. 

It excludes the sources that starts with http:// or https:// or /.

If image source starts with './' i.e. image is in the same folder as
content, then it will replace ./ with content directory path and then
adds the rootpath.

Once image source is fixed, it should not break, no matter from where
content is accessed i.e. index or individual page.