### PR TITLE
Image path prefixed with site host

### DIFF
--- a/src/main/java/org/jbake/app/Crawler.java
+++ b/src/main/java/org/jbake/app/Crawler.java
@@ -13,6 +13,7 @@ import org.jbake.app.Crawler.Attributes.Status;
 import org.jbake.model.DocumentAttributes;
 import org.jbake.model.DocumentStatus;
 import org.jbake.model.DocumentTypes;
+import org.jbake.util.HtmlUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,7 +181,7 @@ public class Crawler {
             
             
             // Prevent image source url's from breaking
-            HtmlUtil.fixImageSourceUrls(fileContents);
+            HtmlUtil.fixImageSourceUrls(fileContents,config);
 
             ODocument doc = new ODocument(documentType);
             doc.fields(fileContents);

--- a/src/test/java/org/jbake/util/HtmlUtilTest.java
+++ b/src/test/java/org/jbake/util/HtmlUtilTest.java
@@ -1,16 +1,28 @@
-package org.jbake.app;
+package org.jbake.util;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.configuration.CompositeConfiguration;
+import org.jbake.app.ConfigUtil;
 import org.jbake.app.Crawler.Attributes;
+import org.jbake.util.HtmlUtil;
+import org.junit.Before;
 import org.junit.Test;
 
 
 
 public class HtmlUtilTest {
+	
+	private CompositeConfiguration config;
+	
+	@Before
+	public void setUp() throws Exception{
+		config = ConfigUtil.load(new File(this.getClass().getResource("/fixture").getFile()));
+	}
 
 	@Test
 	public void shouldAddRootpath(){
@@ -19,9 +31,11 @@ public class HtmlUtilTest {
 		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
 		fileContent.put(Attributes.BODY, "<div> Test <img src='blog/2017/05/first.jpg' /></div>");
 		
-		HtmlUtil.fixImageSourceUrls(fileContent);
+		HtmlUtil.fixImageSourceUrls(fileContent, config);
 		
-		assertTrue(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
+		String body = fileContent.get(Attributes.BODY).toString();
+		
+		assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 		
 	}
 	
@@ -32,9 +46,11 @@ public class HtmlUtilTest {
 		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
 		fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
 		
-		HtmlUtil.fixImageSourceUrls(fileContent);
+		HtmlUtil.fixImageSourceUrls(fileContent, config);
 		
-		assertTrue(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
+		String body = fileContent.get(Attributes.BODY).toString();
+		
+		assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 		
 	}
 	
@@ -45,10 +61,11 @@ public class HtmlUtilTest {
 		fileContent.put(Attributes.URI, "blog/2017/05/first_post.html");
 		fileContent.put(Attributes.BODY, "<div> Test <img src='/blog/2017/05/first.jpg' /></div>");
 		
-		HtmlUtil.fixImageSourceUrls(fileContent);
+		HtmlUtil.fixImageSourceUrls(fileContent,config);
 		
-		assertFalse(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
-		assertTrue(fileContent.get(Attributes.BODY).toString().contains("/blog/2017/05/first.jpg"));
+		String body = fileContent.get(Attributes.BODY).toString();
+		
+		assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 		
 	}
 	
@@ -60,9 +77,11 @@ public class HtmlUtilTest {
 		fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
 		fileContent.put(Attributes.BODY, "<div> Test <img src='blog/2017/05/first.jpg' /></div>");
 		
-		HtmlUtil.fixImageSourceUrls(fileContent);
+		HtmlUtil.fixImageSourceUrls(fileContent, config);
 		
-		assertTrue(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
+		String body = fileContent.get(Attributes.BODY).toString();
+		
+		assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 
 	}
 	
@@ -74,10 +93,11 @@ public class HtmlUtilTest {
 		fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
 		fileContent.put(Attributes.BODY, "<div> Test <img src='./first.jpg' /></div>");
 		
-		HtmlUtil.fixImageSourceUrls(fileContent);
+		HtmlUtil.fixImageSourceUrls(fileContent, config);
 		
-		assertTrue(fileContent.get(Attributes.BODY).toString().contains("../../../blog/2017/05/first.jpg"));
-
+		String body = fileContent.get(Attributes.BODY).toString();
+		
+		assertThat(body).contains("src=\"http://www.jbake.org/blog/2017/05/first.jpg\"");
 	}
 	
 	@Test
@@ -88,8 +108,11 @@ public class HtmlUtilTest {
 		fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
 		fileContent.put(Attributes.BODY, "<div> Test <img src='http://example.com/first.jpg' /></div>");
 		
-		HtmlUtil.fixImageSourceUrls(fileContent);
-		assertTrue(fileContent.get(Attributes.BODY).toString().contains("http://example.com/first.jpg"));
+		HtmlUtil.fixImageSourceUrls(fileContent, config);
+		
+		String body = fileContent.get(Attributes.BODY).toString();
+		
+		assertThat(body).contains("src=\"http://example.com/first.jpg\"");
 
 	}
 	
@@ -101,8 +124,10 @@ public class HtmlUtilTest {
 		fileContent.put(Attributes.NO_EXTENSION_URI, "blog/2017/05/first_post/");
 		fileContent.put(Attributes.BODY, "<div> Test <img src='https://example.com/first.jpg' /></div>");
 		
-		HtmlUtil.fixImageSourceUrls(fileContent);
-		assertTrue(fileContent.get(Attributes.BODY).toString().contains("https://example.com/first.jpg"));
-
+		HtmlUtil.fixImageSourceUrls(fileContent, config);
+		
+		String body = fileContent.get(Attributes.BODY).toString();
+		
+		assertThat(body).contains("src=\"https://example.com/first.jpg\"");
 	}
 }


### PR DESCRIPTION
Replace rootpath with site host

Changed the implementation to prefix the site.host property before
images. Relative paths were breaking in feed.