### PR TITLE
Prevent extra body element after image path correction

### DIFF
--- a/src/main/java/org/jbake/util/HtmlUtil.java
+++ b/src/main/java/org/jbake/util/HtmlUtil.java
@@ -74,8 +74,9 @@ public class HtmlUtil {
 			}
 		}
     	
-    	//User body().children() to prevent adding <body></body> wrap.
-    	fileContents.put(Attributes.BODY, document.body().children().toString());
+    	
+    	//Use body().html() to prevent adding <body></body> from parsed fragment.
+    	fileContents.put(Attributes.BODY, document.body().html());
     }
 	
 }


### PR DESCRIPTION
Corrected JSOUP api method call to prevent empty body during test
execution. This would also prevent extra body element in parsed
fragment.